### PR TITLE
Properly package symlinks

### DIFF
--- a/package/yast-in-container.changes
+++ b/package/yast-in-container.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun  9 13:06:24 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Properly package symlinks
+- 4.5.4
+
+-------------------------------------------------------------------
 Wed Jun  8 14:56:33 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added visual feedback when downloading the container image

--- a/package/yast-in-container.spec
+++ b/package/yast-in-container.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast-in-container
-Version:        4.5.3
+Version:        4.5.4
 Release:        0
 Summary:        Experimental package for running YaST in a container
 License:        GPL-2.0-only
@@ -48,8 +48,8 @@ the host system.
 # install main scripts
 mkdir -p %{buildroot}/%{_sbindir}
 install -m 755 src/scripts/yast2_container %{buildroot}/%{_sbindir}
-install -m 755 src/scripts/yast2_web_container %{buildroot}/%{_sbindir}
-install -m 755 src/scripts/yast_container %{buildroot}/%{_sbindir}
+ln -s yast2_container %{buildroot}/%{_sbindir}/yast_container
+ln -s yast2_container %{buildroot}/%{_sbindir}/yast2_web_container
 
 # install desktop file
 mkdir -p %{buildroot}/%{_datadir}/applications


### PR DESCRIPTION
## Problem

I made a mistake, the `install` command actually follows the symlink instead of copying it. As the result the script was packaged three times in the RPM.

## Solution

Use the `ln` call to create the symlinks.

## Testing

Tested with manually built package, the package is smaller and still works fine
