### PR TITLE
Enable mount propagation between the container and the host

### DIFF
--- a/package/yast-in-container.changes
+++ b/package/yast-in-container.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 19 10:07:48 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Enable mount propagation between the container and the host
+- 4.5.6
+
+-------------------------------------------------------------------
 Fri Jun 17 13:51:27 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Use the SLE BCI based container images

--- a/package/yast-in-container.spec
+++ b/package/yast-in-container.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast-in-container
-Version:        4.5.5
+Version:        4.5.6
 Release:        0
 Summary:        Experimental package for running YaST in a container
 License:        GPL-2.0-only

--- a/src/scripts/yast2_container
+++ b/src/scripts/yast2_container
@@ -129,6 +129,7 @@ set -x
 
 # start the container
 $TOOL run -it --privileged --pid=host --ipc=host --net=host \
-    -v /dev:/dev -v /:$CHROOT_DIR "${EXTRA_OPTIONS[@]}" \
+    -v /dev:/dev "${EXTRA_OPTIONS[@]}" \
+    --mount type=bind,source=/,target=$CHROOT_DIR,bind-propagation=rshared \
     -e ZYPP_LOCKFILE_ROOT=$CHROOT_DIR -e YAST_SCR_TARGET=$CHROOT_DIR \
     --rm $IMAGE_NAME "$CMD" "$@" "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
## Problem

- The mounts done in the container were not propagated to the host

## Solution

- Use the `rshared` mount option, see more details in the Docker documentation: https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation