### PR TITLE
Set `LIBSTORAGE_LOCKFILE_ROOT` to the target root system

### DIFF
--- a/package/yast-in-container.changes
+++ b/package/yast-in-container.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 20 10:02:16 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Set `LIBSTORAGE_LOCKFILE_ROOT` to the target root system
+- 4.5.7
+
+-------------------------------------------------------------------
 Tue Jul 19 10:07:48 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Enable mount propagation between the container and the host

--- a/package/yast-in-container.spec
+++ b/package/yast-in-container.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast-in-container
-Version:        4.5.6
+Version:        4.5.7
 Release:        0
 Summary:        Experimental package for running YaST in a container
 License:        GPL-2.0-only

--- a/src/scripts/yast2_container
+++ b/src/scripts/yast2_container
@@ -132,4 +132,5 @@ $TOOL run -it --privileged --pid=host --ipc=host --net=host \
     -v /dev:/dev "${EXTRA_OPTIONS[@]}" \
     --mount type=bind,source=/,target=$CHROOT_DIR,bind-propagation=rshared \
     -e ZYPP_LOCKFILE_ROOT=$CHROOT_DIR -e YAST_SCR_TARGET=$CHROOT_DIR \
+    -e LIBSTORAGE_LOCKFILE_ROOT=$CHROOT_DIR \
     --rm $IMAGE_NAME "$CMD" "$@" "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
- Save the libstorage lock in the target system
- Similar to the libzypp solution