### PR TITLE
Fix libstorage-ng probing

### DIFF
--- a/package/yast-in-container.changes
+++ b/package/yast-in-container.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jul 25 15:31:45 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Set `LIBSTORAGE_ROOTPREFIX` to improve libstorage-ng probing
+  (bsc#1199840).
+- 4.5.8
+
+-------------------------------------------------------------------
 Wed Jul 20 10:02:16 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Set `LIBSTORAGE_LOCKFILE_ROOT` to the target root system

--- a/package/yast-in-container.spec
+++ b/package/yast-in-container.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast-in-container
-Version:        4.5.7
+Version:        4.5.8
 Release:        0
 Summary:        Experimental package for running YaST in a container
 License:        GPL-2.0-only

--- a/src/scripts/yast2_container
+++ b/src/scripts/yast2_container
@@ -132,5 +132,5 @@ $TOOL run -it --privileged --pid=host --ipc=host --net=host \
     -v /dev:/dev "${EXTRA_OPTIONS[@]}" \
     --mount type=bind,source=/,target=$CHROOT_DIR,bind-propagation=rshared \
     -e ZYPP_LOCKFILE_ROOT=$CHROOT_DIR -e YAST_SCR_TARGET=$CHROOT_DIR \
-    -e LIBSTORAGE_LOCKFILE_ROOT=$CHROOT_DIR \
+    -e LIBSTORAGE_LOCKFILE_ROOT=$CHROOT_DIR -e LIBSTORAGE_ROOTPREFIX=$CHROOT_DIR \
     --rm $IMAGE_NAME "$CMD" "$@" "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
## Problem

libstorage-ng probing didn't exactly work because it was not able to recognize it was running in a chroot. For example, the mount points were calculated with the full path from the host system (eg. `/mnt/home`).

## Solution

Set rootprefix for libstorage-ng, so mount points and other aspects are calculated correctly thanks to the changes introduced recently at libstorage-ng like:

- https://github.com/openSUSE/libstorage-ng/pull/884
- https://github.com/openSUSE/libstorage-ng/pull/888
- https://github.com/openSUSE/libstorage-ng/pull/890

## Related changes

For probing to work, the container must contain several basic tools. Almost for sure the package `e2fsprogs` will be needed since it includes the command `lsattr`. But apart from that, the `lvm2` package is needed if LVM is used in the system, `btrfsprogs` is needed if there is some Btrfs file-system, and so on.

This adds a reasonable set of tools to the container images and is very likely needed for libstorage-ng probing to actually work:
https://build.opensuse.org/request/show/991060

## Testing

Tested manually with modules like yast2-bootloader and yast2-kdump and with the Partitioner.