### PR TITLE
add support for TW and ALP

### DIFF
--- a/package/yast-in-container.changes
+++ b/package/yast-in-container.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug  3 13:29:49 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
+
+- add support for opensuse tumbleweed and ALP
+- 4.5.9
+
+-------------------------------------------------------------------
 Mon Jul 25 15:31:45 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Set `LIBSTORAGE_ROOTPREFIX` to improve libstorage-ng probing

--- a/package/yast-in-container.spec
+++ b/package/yast-in-container.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast-in-container
-Version:        4.5.8
+Version:        4.5.9
 Release:        0
 Summary:        Experimental package for running YaST in a container
 License:        GPL-2.0-only

--- a/src/scripts/yast2_container
+++ b/src/scripts/yast2_container
@@ -40,7 +40,7 @@ echo
 # check whether the host system is compatible with the container image,
 # can be disabled with VERSION_CHECK=0, use on your risk!!
 . /etc/os-release
-if [ "$VERSION_CHECK" != "0" ] && { [ "$VERSION_ID" != "15.4" ] || { [ "$ID" != "sles" ] && [ "$ID" != "opensuse-leap" ]; }; }; then
+if [ "$VERSION_CHECK" != "0" ] && [ "$ID" != "opensuse-tumbleweed" ] && [ "$ID" != "alp" ] && { [ "$VERSION_ID" != "15.4" ] || { [ "$ID" != "sles" ] && [ "$ID" != "opensuse-leap" ]; }; }; then
     echo "ERROR: Unsupported system: $PRETTY_NAME" >&2
     echo "Only 'openSUSE Leap 15.4' or 'SLES-15-SP4' systems are curently supported"
     echo "On your risk you can disable this check by setting VERSION_CHECK=0"

--- a/src/scripts/yast2_container
+++ b/src/scripts/yast2_container
@@ -42,7 +42,12 @@ echo
 . /etc/os-release
 if [ "$VERSION_CHECK" != "0" ] && [ "$ID" != "opensuse-tumbleweed" ] && [ "$ID" != "alp" ] && { [ "$VERSION_ID" != "15.4" ] || { [ "$ID" != "sles" ] && [ "$ID" != "opensuse-leap" ]; }; }; then
     echo "ERROR: Unsupported system: $PRETTY_NAME" >&2
-    echo "Only 'openSUSE Leap 15.4' or 'SLES-15-SP4' systems are curently supported"
+    echo "Currently supported systems:"
+    echo "- openSUSE Tumbleweed"
+    echo "- ALP"
+    echo "- openSUSE Leap 15.4"
+    echo "- SLES-15-SP4"
+    echo ""
     echo "On your risk you can disable this check by setting VERSION_CHECK=0"
     exit 1
 fi


### PR DESCRIPTION
## Problem

yast in container reports that it is not supported on opensuse TW and ALP, but it works there and it prevents submission to factory.


## Solution

Add TW and ALP as supported distros.


## Testing

- *Tested manually*

