### PR TITLE
Fixed broken ncurses UI when running in ALP

### DIFF
--- a/package/yast-in-container.changes
+++ b/package/yast-in-container.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug  8 15:08:01 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed broken ncurses UI when running in ALP (pass the TERM
+  variable from the host to the container)
+- 4.5.11
+
+-------------------------------------------------------------------
 Fri Aug  5 04:54:23 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - Add more explicit warning till more official and stable place

--- a/package/yast-in-container.spec
+++ b/package/yast-in-container.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast-in-container
-Version:        4.5.10
+Version:        4.5.11
 Release:        0
 Summary:        Experimental package for running YaST in a container
 License:        GPL-2.0-only

--- a/src/scripts/yast2_container
+++ b/src/scripts/yast2_container
@@ -144,6 +144,6 @@ set -x
 $TOOL run -it --privileged --pid=host --ipc=host --net=host \
     -v /dev:/dev "${EXTRA_OPTIONS[@]}" \
     --mount type=bind,source=/,target=$CHROOT_DIR,bind-propagation=rshared \
-    -e ZYPP_LOCKFILE_ROOT=$CHROOT_DIR -e YAST_SCR_TARGET=$CHROOT_DIR \
+    -e ZYPP_LOCKFILE_ROOT=$CHROOT_DIR -e YAST_SCR_TARGET=$CHROOT_DIR -e TERM \
     -e LIBSTORAGE_LOCKFILE_ROOT=$CHROOT_DIR -e LIBSTORAGE_ROOTPREFIX=$CHROOT_DIR \
     --rm $IMAGE_NAME "$CMD" "$@" "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
- Pass the `TERM` variable from the host to the container
- By default `TERM` is set to `xterm` which does not work well in a plain Linux text console (tty1+)
- Tested also when running via SSH and in Leap 15.4 system, all work fine
- 4.5.11

## Screenshots

Original script running in an ALP VM:
![alp_console_broken](https://user-images.githubusercontent.com/907998/183456116-78bf00b8-a0f4-46b0-8f6e-777fae2f1e5e.png)


Patched script running in an ALP VM: 
![alp_console_fixed](https://user-images.githubusercontent.com/907998/183456212-bb400648-8cd9-4774-948b-96c338417abe.png)


